### PR TITLE
Fix building

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+jit1
+jit2
+jit3
+*.c
+*.h
+*.gch

--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,19 @@
 
-CFLAGS=-O3 -g -std=gnu99 -Ithird_party
+CFLAGS=-O3 -g -std=gnu99 -Ithird_party -D DASM_VERSION=10300
 
 all: jit1 jit2 jit3
 
 jit1: jit1.c
 
-jit2: dynasm-driver.c jit2.h
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o jit2 dynasm-driver.c -DJIT=\"jit2.h\"
-jit2.h: jit2.dasc
-	lua dynasm/dynasm.lua jit2.dasc > jit2.h
+jit2: dynasm-driver.h jit2.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) dynasm-driver.h jit2.c -o jit2
+jit2.c: jit2.dasc
+	lua third_party/dynasm/dynasm.lua jit2.dasc > jit2.c
 
-jit3: dynasm-driver.c jit3.h
-	$(CC) $(CFLAGS) $(CPPFLAGS) -o jit3 dynasm-driver.c -DJIT=\"jit3.h\"
-jit3.h: jit3.dasc
-	lua dynasm/dynasm.lua jit3.dasc > jit3.h
+jit3: dynasm-driver.h jit3.c
+	$(CC) $(CFLAGS) $(CPPFLAGS) dynasm-driver.h jit3.c -o jit3
+jit3.c: jit3.dasc
+	lua third_party/dynasm/dynasm.lua jit3.dasc > jit3.c
+
+clean:
+	rm -f jit1 jit2 jit3

--- a/dynasm-driver.h
+++ b/dynasm-driver.h
@@ -11,8 +11,6 @@ void initjit(dasm_State **state, const void *actionlist);
 void *jitcode(dasm_State **state);
 void free_jitcode(void *code);
 
-#include JIT
-
 void initjit(dasm_State **state, const void *actionlist) {
   dasm_init(state, 1);
   dasm_setup(state, actionlist);

--- a/jit2.dasc
+++ b/jit2.dasc
@@ -1,6 +1,8 @@
 // Most basic DynASM JIT; generates a trivial function that
 // returns a given value, and executes it.
 
+#include "dynasm-driver.h"
+
 // DynASM directives.
 |.arch x64
 |.actionlist actions

--- a/jit3.dasc
+++ b/jit3.dasc
@@ -2,6 +2,8 @@
 
 #include <stdint.h>
 
+#include "dynasm-driver.h"
+
 |.arch x64
 |.actionlist actions
 |


### PR DESCRIPTION
I was unable to run the Makefile as it is now in master. For instance, the path to dynasm in Makefile misses third_party/ route:

```bash
$ make
lua dynasm/dynasm.lua jit2.dasc > jit2.h
lua: cannot open dynasm/dynasm.lua: No such file or directory
Makefile:11: recipe for target 'jit2.h' failed
make: *** [jit2.h] Error 1
```

After fixing that, I got the following error:

```bash
$ make
cc -O3 -g -std=gnu99 -Ithird_party  -o jit2 dynasm-driver.c -DJIT=\"jit2.h\"
/usr/lib/gcc/x86_64-linux-gnu/6/../../../x86_64-linux-gnu/Scrt1.o: In function `_start':
(.text+0x20): undefined reference to `main'
collect2: error: ld returned 1 exit status
Makefile:9: recipe for target 'jit2' failed
make: *** [jit2] Error 1
```

The problem is that *.dasc files are compiled to .h, but they contain the main function. To fix that I turned 
`dynasm-driver.c` into a header and compile the *.dasc files to *.c

After those changes, the Makefile can build the executables now:

```bash
$ make
cc -O3 -g -std=gnu99 -Ithird_party -D DASM_VERSION=10300    jit1.c   -o jit1
cc -O3 -g -std=gnu99 -Ithird_party -D DASM_VERSION=10300  dynasm-driver.h jit2.c -o jit2
cc -O3 -g -std=gnu99 -Ithird_party -D DASM_VERSION=10300  dynasm-driver.h jit3.c -o jit3
```